### PR TITLE
Add running pace units minkm (min/km) and minmile (min/mile) to speed widget

### DIFF
--- a/src/videowidget.cpp
+++ b/src/videowidget.cpp
@@ -85,6 +85,10 @@ VideoWidget::Unit VideoWidget::string2unit(std::string &s) {
 		unit = VideoWidget::UnitMPH;
 	else if (s == "kph")
 		unit = VideoWidget::UnitKPH;
+	else if (s == "minmile")
+		unit = VideoWidget::UnitMinMile;
+	else if (s == "minkm")
+		unit = VideoWidget::UnitMinKm;
 	else if (s == "km")
 		unit = VideoWidget::UnitKm;
 	else if (s == "m")
@@ -172,6 +176,10 @@ std::string VideoWidget::unit2string(VideoWidget::Unit unit, bool label) {
 		return label ? "m/h" : "mph";
 	case VideoWidget::UnitKPH:
 		return label ? "km/h" : "kph";
+	case VideoWidget::UnitMinMile:
+		return "min/mile";
+	case VideoWidget::UnitMinKm:
+		return "min/km";
 	case VideoWidget::UnitKm:
 		return "km";
 	case VideoWidget::UnitMeter:

--- a/src/videowidget.h
+++ b/src/videowidget.h
@@ -57,6 +57,8 @@ public:
 		UnitMPS,
 		UnitMPH,
 		UnitKPH,
+		UnitMinMile,
+		UnitMinKm,
 		UnitKm,
 		UnitMeter,
 		UnitFoot,

--- a/src/widgets/speed.h
+++ b/src/widgets/speed.h
@@ -43,6 +43,7 @@ skip:
 
 	OIIO::ImageBuf * render(const TelemetryData &data, bool &is_update) {
 		char s[128];
+		bool pace_unit = false;
 		double speed = data.speed();
 
 		// Refresh dynamic info
@@ -61,16 +62,39 @@ skip:
 		// Format data
 		no_value_ = !data.hasValue(TelemetryData::DataSpeed);
 
-		if (unit() == VideoWidget::UnitKPH) {
-		}
-		else {
-			speed *= 0.6213711922;
+		switch (unit()) {
+			case VideoWidget::UnitMPH:
+				speed *= 0.6213711922;
+				break;
+			case VideoWidget::UnitKPH:
+				break;
+			case VideoWidget::UnitMinMile:
+				speed *= 0.6213711922;
+				pace_unit = true;
+				break;
+			case VideoWidget::UnitMinKm:
+				pace_unit = true;
+				break;
+			default:
+				break;
 		}
 
-		if (!no_value_)
-			sprintf(s, "%.0f %s", speed, unit2string(unit()).c_str());
-		else
+		if (no_value_) {
 			sprintf(s, "-- %s", unit2string(unit()).c_str());
+		} else {
+			if (pace_unit) {
+				if (speed > 0.0) {
+					double pace = 60.0 / speed;
+					int min = (int)pace;
+					int sec = (int)round((pace - min) * 60) % 60;
+					sprintf(s, "%d:%02d %s", min, sec, unit2string(unit()).c_str());
+				} else {
+					sprintf(s, "∞ %s", unit2string(unit()).c_str());
+				}
+			} else {
+				sprintf(s, "%.1f %s", speed, unit2string(unit()).c_str());
+			}
+		}
 
 		// Refresh dynamic info
 		if (fg_buf_ != NULL)


### PR DESCRIPTION
In running videos, pace is more intuitive than speed for widget overlays. I wrote the code for it if you see value in including it upstream. I added both minutes per kilometer and minutes per mile.